### PR TITLE
Feature/sem 4195

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inspark/components-web",
-  "version": "9.0.11",
+  "version": "9.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inspark/components-web",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inspark/components-web",
-  "version": "9.0.11",
+  "version": "9.0.12",
   "description": "Web components for Inspark products",
   "main": "index.css",
   "author": "Inspark",

--- a/src/base/_mixins.scss
+++ b/src/base/_mixins.scss
@@ -816,14 +816,6 @@
     color: var(--ids-theme-text-color, $text-color);
     background-color: $body-bg;
     background-color: var(--ids-theme-body-bg, $body-bg);
-
-    // убирает зум по двойному тапу на мобильных
-    @media only screen
-    and (min-device-width: 320px)
-    and (max-device-width: 900px)
-    and (-webkit-min-device-pixel-ratio: 2) {
-      touch-action: pan-y;
-    }
   }
 
   // Suppress the focus outline on elements that cannot be accessed via keyboard.

--- a/src/input/_mixins.scss
+++ b/src/input/_mixins.scss
@@ -95,13 +95,13 @@ markup:
 
 @mixin _c-input {
   padding: $unit-tiny $unit-small;
-  line-height: $line-height-computed;
+  line-height: 1.45;
   transition: all, $global-transition;
   border: $form-border_outer;
   border: var(--ids-theme-inuit-forms-border_outer, $form-border_outer);
   border-radius: $global-radius;
   font-family: inherit;
-  font-size: $font-size-base;
+  font-size: 16px;
   outline: 0;
   box-shadow: $form-border-inner;
   box-shadow: var(--ids-theme-inuit-forms-border-inner, $form-border-inner);
@@ -114,6 +114,14 @@ markup:
   -webkit-tap-highlight-color: rgba($input-tap-highlight-color, 0);
   -webkit-tap-highlight-color: rgba(var(--ids-theme-input-tap-highlight-color-rgb, #{$input-tap-highlight-color-rgb}), 0);
   -moz-appearance: none;
+
+  @media only screen
+  and (min-device-width: 320px)
+  and (max-device-width: $screen-limit-larger)
+  and (-webkit-min-device-pixel-ratio: 1.5) {
+    line-height: 1.45;
+    font-size: 16px;
+  }
 
   &::placeholder {
     color: rgba($form-color, 0.6);

--- a/src/select/_mixins.scss
+++ b/src/select/_mixins.scss
@@ -77,6 +77,14 @@ markup:
   -webkit-appearance: none;
   -moz-appearance: none;
 
+  @media only screen
+  and (min-device-width: 320px)
+  and (max-device-width: $screen-limit-larger)
+  and (-webkit-min-device-pixel-ratio: 1.5) {
+    line-height: 1.6;
+    font-size: 16px;
+  }
+
   &:hover {
     border: 1px solid var(--ids-theme-select-border_hover, $select-border_hover);
     box-shadow: var(--ids-theme-select-shadow_dark, $select-shadow_dark);

--- a/src/typography/_mixins.scss
+++ b/src/typography/_mixins.scss
@@ -5,7 +5,7 @@
 //   ======================================================================== */
 
 @mixin reset-text() {
-  font-family: $font-size-base;
+  font-family: $font-family-base;
   // We deliberately do NOT reset font-size.
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
- для мобильных убран авто-зум в браузере при тапе на input, select, textarea через увеличение размера шрифта - предыдущее решение через touch-action: pan-y отключено, т.к. не работало и накладывало сайдэффекты